### PR TITLE
Add scope customizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,31 @@ go get github.com/sdcxtech/sentrytemporal
 
 ```go
 type Options struct {
-	// ActivityErrorSkipper configures a function to determine if an error from activity should be skipped.
-	ActivityErrorSkipper ActivityErrorSkipper
-	// WorkflowErrorSkipper configures a function to determine if an error from workflow should be skipped.
-	WorkflowErrorSkipper WorkflowErrorSkipper
+    // ActivityErrorSkipper configures a function to determine if an error (or panic) from activity should be skipped.
+    // If it returns true, the error is ignored.
+    ActivityErrorSkipper ActivityErrorSkipper
+    // WorkflowErrorSkipper configures a function to determine if an error (or panic) from workflow should be skipped.
+    // If it returns true, the error is ignored.
+    WorkflowErrorSkipper WorkflowErrorSkipper
+    
+    // ActivityScopeCustomizer applies custom options to a sentry.Scope just before an error is reported from an activity
+    ActivityScopeCustomizer ActivityScopeCustomizer
+    // WorkflowScopeCustomizer applies custom options to a sentry.Scope just before an error is reported from a workflow
+    WorkflowScopeCustomizer WorkflowScopeCustomizer
 }
 
 type (
-	ActivityErrorSkipper func(context.Context, error) bool
-	WorkflowErrorSkipper func(workflow.Context, error) bool
+    ActivityErrorSkipper func(context.Context, error) bool
+    WorkflowErrorSkipper func(workflow.Context, error) bool
+
+    ActivityScopeCustomizer func(context.Context, *sentry.Scope, error)
+    WorkflowScopeCustomizer func(workflow.Context, *sentry.Scope, error)
 )
 ```
 
 Example:
 
-Only report retrieable error when attempt count is great then `1`.
+Only report retryable error when attempt count is great then `1`.
 
 ```go
 activityErrorSkipper := func(ctx context.Context, err error) bool {

--- a/activity.go
+++ b/activity.go
@@ -35,6 +35,11 @@ func (a *activityInboundInterceptor) ExecuteActivity(
 				"{{ default }}",
 			},
 		)
+
+		if a.root.options.ActivityScopeCustomizer != nil {
+			a.root.options.ActivityScopeCustomizer(ctx, scope, err)
+		}
+
 	}
 
 	defer func() {

--- a/worker.go
+++ b/worker.go
@@ -10,14 +10,24 @@ import (
 
 type Options struct {
 	// ActivityErrorSkipper configures a function to determine if an error from activity should be skipped.
+	// If it returns true, the error is ignored.
 	ActivityErrorSkipper ActivityErrorSkipper
 	// WorkflowErrorSkipper configures a function to determine if an error from workflow should be skipped.
+	// If it returns true, the error is ignored.
 	WorkflowErrorSkipper WorkflowErrorSkipper
+
+	// ActivityScopeCustomizer applies custom options to a sentry.Scope just before an error is reported from an activity
+	ActivityScopeCustomizer ActivityScopeCustomizer
+	// WorkflowScopeCustomizer applies custom options to a sentry.Scope just before an error is reported from a workflow
+	WorkflowScopeCustomizer WorkflowScopeCustomizer
 }
 
 type (
 	ActivityErrorSkipper func(context.Context, error) bool
 	WorkflowErrorSkipper func(workflow.Context, error) bool
+
+	ActivityScopeCustomizer func(context.Context, *sentry.Scope, error)
+	WorkflowScopeCustomizer func(workflow.Context, *sentry.Scope, error)
 )
 
 // New creates a worker interceptor which will report error to sentry.

--- a/workflow.go
+++ b/workflow.go
@@ -31,6 +31,10 @@ func (w *workflowInboundInterceptor) ExecuteWorkflow(
 				"{{ default }}",
 			},
 		)
+
+		if w.root.options.WorkflowScopeCustomizer != nil {
+			w.root.options.WorkflowScopeCustomizer(ctx, scope, err)
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
Hello! Thanks for starting a project on this useful topic.

I'm proposing the ability to add additional information to the sentry scope, as errors are reported. We're using this to add contextual data, like trace IDs.

I've also changed the error skippers to be tested during panics as well.

Let me know what you think.